### PR TITLE
feat: update to 3.5.3

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
 
-
 export declare enum TrackOpTypes {
     GET = "get",
     HAS = "has",
@@ -17,190 +16,16 @@ export declare enum ReactiveFlags {
     IS_REACTIVE = "__v_isReactive",
     IS_READONLY = "__v_isReadonly",
     IS_SHALLOW = "__v_isShallow",
-    RAW = "__v_raw"
+    RAW = "__v_raw",
+    IS_REF = "__v_isRef"
 }
-
-type Dep = Map<ReactiveEffect, number> & {
-    cleanup: () => void;
-    computed?: ComputedRefImpl<any>;
-};
-
-export declare class EffectScope {
-    detached: boolean;
-    constructor(detached?: boolean);
-    get active(): boolean;
-    run<T>(fn: () => T): T | undefined;
-    stop(fromParent?: boolean): void;
-}
-/**
- * Creates an effect scope object which can capture the reactive effects (i.e.
- * computed and watchers) created within it so that these effects can be
- * disposed together. For detailed use cases of this API, please consult its
- * corresponding {@link https://github.com/vuejs/rfcs/blob/master/active-rfcs/0041-reactivity-effect-scope.md | RFC}.
- *
- * @param detached - Can be used to create a "detached" effect scope.
- * @see {@link https://vuejs.org/api/reactivity-advanced.html#effectscope}
- */
-export declare function effectScope(detached?: boolean): EffectScope;
-/**
- * Returns the current active effect scope if there is one.
- *
- * @see {@link https://vuejs.org/api/reactivity-advanced.html#getcurrentscope}
- */
-export declare function getCurrentScope(): EffectScope | undefined;
-/**
- * Registers a dispose callback on the current active effect scope. The
- * callback will be invoked when the associated effect scope is stopped.
- *
- * @param fn - The callback function to attach to the scope's cleanup.
- * @see {@link https://vuejs.org/api/reactivity-advanced.html#onscopedispose}
- */
-export declare function onScopeDispose(fn: () => void): void;
-
-export type EffectScheduler = (...args: any[]) => any;
-export type DebuggerEvent = {
-    effect: ReactiveEffect;
-} & DebuggerEventExtraInfo;
-export type DebuggerEventExtraInfo = {
-    target: object;
-    type: TrackOpTypes | TriggerOpTypes;
-    key: any;
-    newValue?: any;
-    oldValue?: any;
-    oldTarget?: Map<any, any> | Set<any>;
-};
-export declare class ReactiveEffect<T = any> {
-    fn: () => T;
-    trigger: () => void;
-    scheduler?: EffectScheduler | undefined;
-    active: boolean;
-    deps: Dep[];
-    onStop?: () => void;
-    onTrack?: (event: DebuggerEvent) => void;
-    onTrigger?: (event: DebuggerEvent) => void;
-    constructor(fn: () => T, trigger: () => void, scheduler?: EffectScheduler | undefined, scope?: EffectScope);
-    get dirty(): boolean;
-    set dirty(v: boolean);
-    run(): T;
-    stop(): void;
-}
-export interface DebuggerOptions {
-    onTrack?: (event: DebuggerEvent) => void;
-    onTrigger?: (event: DebuggerEvent) => void;
-}
-export interface ReactiveEffectOptions extends DebuggerOptions {
-    lazy?: boolean;
-    scheduler?: EffectScheduler;
-    scope?: EffectScope;
-    allowRecurse?: boolean;
-    onStop?: () => void;
-}
-export interface ReactiveEffectRunner<T = any> {
-    (): T;
-    effect: ReactiveEffect;
-}
-/**
- * Registers the given function to track reactive updates.
- *
- * The given function will be run once immediately. Every time any reactive
- * property that's accessed within it gets updated, the function will run again.
- *
- * @param fn - The function that will track reactive updates.
- * @param options - Allows to control the effect's behaviour.
- * @returns A runner that can be used to control the effect after creation.
- */
-export declare function effect<T = any>(fn: () => T, options?: ReactiveEffectOptions): ReactiveEffectRunner;
-/**
- * Stops the effect associated with the given runner.
- *
- * @param runner - Association with the effect to stop tracking.
- */
-export declare function stop(runner: ReactiveEffectRunner): void;
-/**
- * Temporarily pauses tracking.
- */
-export declare function pauseTracking(): void;
-/**
- * Re-enables effect tracking (if it was paused).
- */
-export declare function enableTracking(): void;
-/**
- * Resets the previous global effect tracking state.
- */
-export declare function resetTracking(): void;
-export declare function pauseScheduling(): void;
-export declare function resetScheduling(): void;
-
-declare const ComputedRefSymbol: unique symbol;
-export interface ComputedRef<T = any> extends WritableComputedRef<T> {
-    readonly value: T;
-    [ComputedRefSymbol]: true;
-}
-export interface WritableComputedRef<T> extends Ref<T> {
-    readonly effect: ReactiveEffect<T>;
-}
-export type ComputedGetter<T> = (oldValue?: T) => T;
-export type ComputedSetter<T> = (newValue: T) => void;
-export interface WritableComputedOptions<T> {
-    get: ComputedGetter<T>;
-    set: ComputedSetter<T>;
-}
-export declare class ComputedRefImpl<T> {
-    private getter;
-    private readonly _setter;
-    dep?: Dep;
-    private _value;
-    readonly effect: ReactiveEffect<T>;
-    readonly __v_isRef = true;
-    readonly [ReactiveFlags.IS_READONLY]: boolean;
-    _cacheable: boolean;
-    /**
-     * Dev only
-     */
-    _warnRecursive?: boolean;
-    constructor(getter: ComputedGetter<T>, _setter: ComputedSetter<T>, isReadonly: boolean, isSSR: boolean);
-    get value(): T;
-    set value(newValue: T);
-    get _dirty(): boolean;
-    set _dirty(v: boolean);
-}
-/**
- * Takes a getter function and returns a readonly reactive ref object for the
- * returned value from the getter. It can also take an object with get and set
- * functions to create a writable ref object.
- *
- * @example
- * ```js
- * // Creating a readonly computed ref:
- * const count = ref(1)
- * const plusOne = computed(() => count.value + 1)
- *
- * console.log(plusOne.value) // 2
- * plusOne.value++ // error
- * ```
- *
- * ```js
- * // Creating a writable computed ref:
- * const count = ref(1)
- * const plusOne = computed({
- *   get: () => count.value + 1,
- *   set: (val) => {
- *     count.value = val - 1
- *   }
- * })
- *
- * plusOne.value = 1
- * console.log(count.value) // 0
- * ```
- *
- * @param getter - Function that produces the next value.
- * @param debugOptions - For debugging. See {@link https://vuejs.org/guide/extras/reactivity-in-depth.html#computed-debugging}.
- * @see {@link https://vuejs.org/api/reactivity-core.html#computed}
- */
-export declare function computed<T>(getter: ComputedGetter<T>, debugOptions?: DebuggerOptions): ComputedRef<T>;
-export declare function computed<T>(options: WritableComputedOptions<T>, debugOptions?: DebuggerOptions): WritableComputedRef<T>;
 
 export type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRefSimple<T>;
+declare const ReactiveMarkerSymbol: unique symbol;
+export interface ReactiveMarker {
+    [ReactiveMarkerSymbol]?: void;
+}
+export type Reactive<T> = UnwrapNestedRefs<T> & (T extends readonly any[] ? ReactiveMarker : {});
 /**
  * Returns a reactive proxy of the object.
  *
@@ -216,7 +41,7 @@ export type UnwrapNestedRefs<T> = T extends Ref ? T : UnwrapRefSimple<T>;
  * @param target - The source object.
  * @see {@link https://vuejs.org/api/reactivity-core.html#reactive}
  */
-export declare function reactive<T extends object>(target: T): UnwrapNestedRefs<T>;
+export declare function reactive<T extends object>(target: T): Reactive<T>;
 declare const ShallowReactiveMarker: unique symbol;
 export type ShallowReactive<T> = T & {
     [ShallowReactiveMarker]?: true;
@@ -408,11 +233,189 @@ export type Raw<T> = T & {
  * @see {@link https://vuejs.org/api/reactivity-advanced.html#markraw}
  */
 export declare function markRaw<T extends object>(value: T): Raw<T>;
+/**
+ * Returns a reactive proxy of the given value (if possible).
+ *
+ * If the given value is not an object, the original value itself is returned.
+ *
+ * @param value - The value for which a reactive proxy shall be created.
+ */
+export declare const toReactive: <T extends unknown>(value: T) => T;
+/**
+ * Returns a readonly proxy of the given value (if possible).
+ *
+ * If the given value is not an object, the original value itself is returned.
+ *
+ * @param value - The value for which a readonly proxy shall be created.
+ */
+export declare const toReadonly: <T extends unknown>(value: T) => DeepReadonly<T>;
+
+export type EffectScheduler = (...args: any[]) => any;
+export type DebuggerEvent = {
+    effect: Subscriber;
+} & DebuggerEventExtraInfo;
+export type DebuggerEventExtraInfo = {
+    target: object;
+    type: TrackOpTypes | TriggerOpTypes;
+    key: any;
+    newValue?: any;
+    oldValue?: any;
+    oldTarget?: Map<any, any> | Set<any>;
+};
+export interface DebuggerOptions {
+    onTrack?: (event: DebuggerEvent) => void;
+    onTrigger?: (event: DebuggerEvent) => void;
+}
+export interface ReactiveEffectOptions extends DebuggerOptions {
+    scheduler?: EffectScheduler;
+    allowRecurse?: boolean;
+    onStop?: () => void;
+}
+export declare enum EffectFlags {
+    ACTIVE = 1,
+    RUNNING = 2,
+    TRACKING = 4,
+    NOTIFIED = 8,
+    DIRTY = 16,
+    ALLOW_RECURSE = 32,
+    PAUSED = 64
+}
+/**
+ * Subscriber is a type that tracks (or subscribes to) a list of deps.
+ */
+interface Subscriber extends DebuggerOptions {
+}
+export declare class ReactiveEffect<T = any> implements Subscriber, ReactiveEffectOptions {
+    fn: () => T;
+    scheduler?: EffectScheduler;
+    onStop?: () => void;
+    onTrack?: (event: DebuggerEvent) => void;
+    onTrigger?: (event: DebuggerEvent) => void;
+    constructor(fn: () => T);
+    pause(): void;
+    resume(): void;
+    run(): T;
+    stop(): void;
+    trigger(): void;
+    get dirty(): boolean;
+}
+export interface ReactiveEffectRunner<T = any> {
+    (): T;
+    effect: ReactiveEffect;
+}
+export interface ReactiveEffectRunner<T = any> {
+    (): T;
+    effect: ReactiveEffect;
+}
+export declare function effect<T = any>(fn: () => T, options?: ReactiveEffectOptions): ReactiveEffectRunner<T>;
+/**
+ * Stops the effect associated with the given runner.
+ *
+ * @param runner - Association with the effect to stop tracking.
+ */
+export declare function stop(runner: ReactiveEffectRunner): void;
+/**
+ * Temporarily pauses tracking.
+ */
+export declare function pauseTracking(): void;
+/**
+ * Re-enables effect tracking (if it was paused).
+ */
+export declare function enableTracking(): void;
+/**
+ * Resets the previous global effect tracking state.
+ */
+export declare function resetTracking(): void;
+/**
+ * Registers a cleanup function for the current active effect.
+ * The cleanup function is called right before the next effect run, or when the
+ * effect is stopped.
+ *
+ * Throws a warning if there is no current active effect. The warning can be
+ * suppressed by passing `true` to the second argument.
+ *
+ * @param fn - the cleanup function to be registered
+ * @param failSilently - if `true`, will not throw warning when called without
+ * an active effect.
+ */
+export declare function onEffectCleanup(fn: () => void, failSilently?: boolean): void;
+
+declare const ComputedRefSymbol: unique symbol;
+declare const WritableComputedRefSymbol: unique symbol;
+interface BaseComputedRef<T, S = T> extends Ref<T, S> {
+    [ComputedRefSymbol]: true;
+    /**
+     * @deprecated computed no longer uses effect
+     */
+    effect: ComputedRefImpl;
+}
+export interface ComputedRef<T = any> extends BaseComputedRef<T> {
+    readonly value: T;
+}
+export interface WritableComputedRef<T, S = T> extends BaseComputedRef<T, S> {
+    [WritableComputedRefSymbol]: true;
+}
+export type ComputedGetter<T> = (oldValue?: T) => T;
+export type ComputedSetter<T> = (newValue: T) => void;
+export interface WritableComputedOptions<T, S = T> {
+    get: ComputedGetter<T>;
+    set: ComputedSetter<S>;
+}
+/**
+ * @private exported by @vue/reactivity for Vue core use, but not exported from
+ * the main vue package
+ */
+export declare class ComputedRefImpl<T = any> implements Subscriber {
+    fn: ComputedGetter<T>;
+    private readonly setter;
+    effect: this;
+    onTrack?: (event: DebuggerEvent) => void;
+    onTrigger?: (event: DebuggerEvent) => void;
+    constructor(fn: ComputedGetter<T>, setter: ComputedSetter<T> | undefined, isSSR: boolean);
+    get value(): T;
+    set value(newValue: T);
+}
+/**
+ * Takes a getter function and returns a readonly reactive ref object for the
+ * returned value from the getter. It can also take an object with get and set
+ * functions to create a writable ref object.
+ *
+ * @example
+ * ```js
+ * // Creating a readonly computed ref:
+ * const count = ref(1)
+ * const plusOne = computed(() => count.value + 1)
+ *
+ * console.log(plusOne.value) // 2
+ * plusOne.value++ // error
+ * ```
+ *
+ * ```js
+ * // Creating a writable computed ref:
+ * const count = ref(1)
+ * const plusOne = computed({
+ *   get: () => count.value + 1,
+ *   set: (val) => {
+ *     count.value = val - 1
+ *   }
+ * })
+ *
+ * plusOne.value = 1
+ * console.log(count.value) // 0
+ * ```
+ *
+ * @param getter - Function that produces the next value.
+ * @param debugOptions - For debugging. See {@link https://vuejs.org/guide/extras/reactivity-in-depth.html#computed-debugging}.
+ * @see {@link https://vuejs.org/api/reactivity-core.html#computed}
+ */
+export declare function computed<T>(getter: ComputedGetter<T>, debugOptions?: DebuggerOptions): ComputedRef<T>;
+export declare function computed<T, S = T>(options: WritableComputedOptions<T, S>, debugOptions?: DebuggerOptions): WritableComputedRef<T, S>;
 
 declare const RefSymbol: unique symbol;
 declare const RawSymbol: unique symbol;
-export interface Ref<T = any> {
-    value: T;
+export interface Ref<T = any, S = T> {
+    get value(): T;
+    set value(_: S);
     /**
      * Type differentiator only.
      * We need this to be in public d.ts but don't want it to show up in IDE
@@ -434,7 +437,7 @@ export declare function isRef<T>(r: Ref<T> | unknown): r is Ref<T>;
  * @param value - The object to wrap in the ref.
  * @see {@link https://vuejs.org/api/reactivity-core.html#ref}
  */
-export declare function ref<T>(value: T): Ref<UnwrapRef<T>>;
+export declare function ref<T>(value: T): [T] extends [Ref] ? IfAny<T, Ref<T>, T> : Ref<UnwrapRef<T>, UnwrapRef<T> | T>;
 export declare function ref<T = any>(): Ref<T | undefined>;
 declare const ShallowRefMarker: unique symbol;
 export type ShallowRef<T = any> = Ref<T> & {
@@ -485,8 +488,8 @@ export declare function shallowRef<T = any>(): ShallowRef<T | undefined>;
  * @see {@link https://vuejs.org/api/reactivity-advanced.html#triggerref}
  */
 export declare function triggerRef(ref: Ref): void;
-export type MaybeRef<T = any> = T | Ref<T>;
-export type MaybeRefOrGetter<T = any> = MaybeRef<T> | (() => T);
+export type MaybeRef<T = any> = T | Ref<T> | ShallowRef<T> | WritableComputedRef<T>;
+export type MaybeRefOrGetter<T = any> = MaybeRef<T> | ComputedRef<T> | (() => T);
 /**
  * Returns the inner value if the argument is a ref, otherwise return the
  * argument itself. This is a sugar function for
@@ -520,13 +523,11 @@ export declare function unref<T>(ref: MaybeRef<T> | ComputedRef<T>): T;
  * @param source - A getter, an existing ref, or a non-function value.
  * @see {@link https://vuejs.org/api/reactivity-utilities.html#tovalue}
  */
-export declare function toValue<T>(source: MaybeRefOrGetter<T> | ComputedRef<T>): T;
+export declare function toValue<T>(source: MaybeRefOrGetter<T>): T;
 /**
- * Returns a reactive proxy for the given object.
- *
- * If the object already is reactive, it's returned as-is. If not, a new
- * reactive proxy is created. Direct child properties that are refs are properly
- * handled, as well.
+ * Returns a proxy for the given object that shallowly unwraps properties that
+ * are refs. If the object already is reactive, it's returned as-is. If not, a
+ * new reactive proxy is created.
  *
  * @param objectWithRefs - Either an already-reactive object or a simple object
  * that contains refs.
@@ -603,7 +604,6 @@ export type ToRef<T> = IfAny<T, Ref<T>, [T] extends [Ref] ? T : Ref<T>>;
 export declare function toRef<T>(value: T): T extends () => infer R ? Readonly<Ref<R>> : T extends Ref ? T : Ref<UnwrapRef<T>>;
 export declare function toRef<T extends object, K extends keyof T>(object: T, key: K): ToRef<T[K]>;
 export declare function toRef<T extends object, K extends keyof T>(object: T, key: K, defaultValue: T[K]): ToRef<Exclude<T[K], undefined>>;
-type BaseTypes = string | number | boolean;
 /**
  * This is a special exported interface for other packages to declare
  * additional types that should bail out for ref unwrapping. For example
@@ -620,11 +620,11 @@ type BaseTypes = string | number | boolean;
 export interface RefUnwrapBailTypes {
 }
 export type ShallowUnwrapRef<T> = {
-    [K in keyof T]: DistrubuteRef<T[K]>;
+    [K in keyof T]: DistributeRef<T[K]>;
 };
-type DistrubuteRef<T> = T extends Ref<infer V> ? V : T;
+type DistributeRef<T> = T extends Ref<infer V> ? V : T;
 export type UnwrapRef<T> = T extends ShallowRef<infer V> ? V : T extends Ref<infer V> ? UnwrapRefSimple<V> : UnwrapRefSimple<T>;
-type UnwrapRefSimple<T> = T extends Function | BaseTypes | Ref | RefUnwrapBailTypes[keyof RefUnwrapBailTypes] | {
+type UnwrapRefSimple<T> = T extends Builtin | Ref | RefUnwrapBailTypes[keyof RefUnwrapBailTypes] | {
     [RawSymbol]?: true;
 } ? T : T extends Map<infer K, infer V> ? Map<K, UnwrapRefSimple<V>> & UnwrapRef<Omit<T, keyof Map<any, any>>> : T extends WeakMap<infer K, infer V> ? WeakMap<K, UnwrapRefSimple<V>> & UnwrapRef<Omit<T, keyof WeakMap<any, any>>> : T extends Set<infer V> ? Set<UnwrapRefSimple<V>> & UnwrapRef<Omit<T, keyof Set<any>>> : T extends WeakSet<infer V> ? WeakSet<UnwrapRefSimple<V>> & UnwrapRef<Omit<T, keyof WeakSet<any>>> : T extends ReadonlyArray<any> ? {
     [K in keyof T]: UnwrapRefSimple<T[K]>;
@@ -634,12 +634,9 @@ type UnwrapRefSimple<T> = T extends Function | BaseTypes | Ref | RefUnwrapBailTy
     [P in keyof T]: P extends symbol ? T[P] : UnwrapRef<T[P]>;
 } : T;
 
-/**
- * @deprecated use `computed` instead. See #5912
- */
-export declare const deferredComputed: typeof computed;
-
 export declare const ITERATE_KEY: unique symbol;
+export declare const MAP_KEY_ITERATE_KEY: unique symbol;
+export declare const ARRAY_ITERATE_KEY: unique symbol;
 /**
  * Tracks access to a reactive property.
  *
@@ -660,4 +657,95 @@ export declare function track(target: object, type: TrackOpTypes, key: unknown):
  * @param key - Can be used to target a specific reactive property in the target object.
  */
 export declare function trigger(target: object, type: TriggerOpTypes, key?: unknown, newValue?: unknown, oldValue?: unknown, oldTarget?: Map<unknown, unknown> | Set<unknown>): void;
+
+export declare class EffectScope {
+    detached: boolean;
+    private _isPaused;
+    constructor(detached?: boolean);
+    get active(): boolean;
+    pause(): void;
+    /**
+     * Resumes the effect scope, including all child scopes and effects.
+     */
+    resume(): void;
+    run<T>(fn: () => T): T | undefined;
+    stop(fromParent?: boolean): void;
+}
+/**
+ * Creates an effect scope object which can capture the reactive effects (i.e.
+ * computed and watchers) created within it so that these effects can be
+ * disposed together. For detailed use cases of this API, please consult its
+ * corresponding {@link https://github.com/vuejs/rfcs/blob/master/active-rfcs/0041-reactivity-effect-scope.md | RFC}.
+ *
+ * @param detached - Can be used to create a "detached" effect scope.
+ * @see {@link https://vuejs.org/api/reactivity-advanced.html#effectscope}
+ */
+export declare function effectScope(detached?: boolean): EffectScope;
+/**
+ * Returns the current active effect scope if there is one.
+ *
+ * @see {@link https://vuejs.org/api/reactivity-advanced.html#getcurrentscope}
+ */
+export declare function getCurrentScope(): EffectScope | undefined;
+/**
+ * Registers a dispose callback on the current active effect scope. The
+ * callback will be invoked when the associated effect scope is stopped.
+ *
+ * @param fn - The callback function to attach to the scope's cleanup.
+ * @see {@link https://vuejs.org/api/reactivity-advanced.html#onscopedispose}
+ */
+export declare function onScopeDispose(fn: () => void, failSilently?: boolean): void;
+
+/**
+ * Track array iteration and return:
+ * - if input is reactive: a cloned raw array with reactive values
+ * - if input is non-reactive or shallowReactive: the original raw array
+ */
+export declare function reactiveReadArray<T>(array: T[]): T[];
+/**
+ * Track array iteration and return raw array
+ */
+export declare function shallowReadArray<T>(arr: T[]): T[];
+
+export declare enum WatchErrorCodes {
+    WATCH_GETTER = 2,
+    WATCH_CALLBACK = 3,
+    WATCH_CLEANUP = 4
+}
+export type WatchEffect = (onCleanup: OnCleanup) => void;
+export type WatchSource<T = any> = Ref<T, any> | ComputedRef<T> | (() => T);
+export type WatchCallback<V = any, OV = any> = (value: V, oldValue: OV, onCleanup: OnCleanup) => any;
+export type OnCleanup = (cleanupFn: () => void) => void;
+export interface WatchOptions<Immediate = boolean> extends DebuggerOptions {
+    immediate?: Immediate;
+    deep?: boolean | number;
+    once?: boolean;
+    scheduler?: WatchScheduler;
+    onWarn?: (msg: string, ...args: any[]) => void;
+}
+export type WatchStopHandle = () => void;
+export interface WatchHandle extends WatchStopHandle {
+    pause: () => void;
+    resume: () => void;
+    stop: () => void;
+}
+export type WatchScheduler = (job: () => void, isFirstRun: boolean) => void;
+/**
+ * Returns the current active effect if there is one.
+ */
+export declare function getCurrentWatcher(): ReactiveEffect<any> | undefined;
+/**
+ * Registers a cleanup callback on the current active effect. This
+ * registered cleanup callback will be invoked right before the
+ * associated effect re-runs.
+ *
+ * @param cleanupFn - The callback function to attach to the effect's cleanup.
+ * @param failSilently - if `true`, will not throw warning when called without
+ * an active effect.
+ * @param owner - The effect that this cleanup function should be attached to.
+ * By default, the current active effect.
+ */
+export declare function onWatcherCleanup(cleanupFn: () => void, failSilently?: boolean, owner?: ReactiveEffect | undefined): void;
+export declare function watch(source: WatchSource | WatchSource[] | WatchEffect | object, cb?: WatchCallback | null, options?: WatchOptions): WatchHandle;
+export declare function traverse(value: unknown, depth?: number, seen?: Set<unknown>): unknown;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuuang/vue-reactivity-miniprogram",
-  "version": "3.4.28",
+  "version": "3.5.3",
   "description": "vue-reactivity for miniprogram",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
1. support `watch` method
2. get/set in interface only support TS>=5.1.6
```
export interface Ref<T = any, S = T> {
    get value(): T;
    set value(_: S);
    /**
     * Type differentiator only.
     * We need this to be in public d.ts but don't want it to show up in IDE
     * autocomplete, so we use a private Symbol instead.
     */
    [RefSymbol]: true;
}
```